### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "zydis"
+description := "Zyan Core Library for C providing platform independent types, macros and a fallback for environments without a libc."
+gitrepo     := "https://github.com/zyantific/zycore-c.git"
+homepage    := "https://github.com/zyantific/zycore-c/"
+license     := "MIT"
+version     := 482298a sha256:5df9ed5a45d7dc71c6fc18405bc72811a99cff0a814c879177e0a11c58fc5ad6 https://github.com/zyantific/zycore-c/archive/482298a.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

